### PR TITLE
Bug? BasicSourceName is called twice, with different types of strings…

### DIFF
--- a/PyAedatTools/BasicSourceName.py
+++ b/PyAedatTools/BasicSourceName.py
@@ -59,4 +59,4 @@ def BasicSourceName(inp):
         'das1': 'Das1',
         'cochleaams1c': 'CochleaAms1c'}
 
-    return devices.get(inp.lower()[:-2], 'Dvs128')  # Cut off '\r'
+    return devices.get(inp.lower(), 'Dvs128')

--- a/PyAedatTools/ImportAedatHeaders.py
+++ b/PyAedatTools/ImportAedatHeaders.py
@@ -56,7 +56,7 @@ def ImportAedatHeaders(aedat):
             start_prefix = line.rfind('.')
             if start_prefix == -1:
                 start_prefix = 9    
-            sourceFromFile = BasicSourceName(line[start_prefix :])
+            sourceFromFile = BasicSourceName(line[start_prefix+1:-2]) # Cut off '\r'
         # Version 3.0 encodes it like this
         # The following ignores any trace of previous sources
         # (prefixed with a minus sign)


### PR DESCRIPTION
…: a string that ends in \r and a clean string.

I suggest to always pass a clean string (without extra, hidden characters) to BasicSourceName.

@simbamford ptal