### PR TITLE
Fix bug "undefined endTime/startTime" in ImportAedatDataVersion1or2.m

### DIFF
--- a/Matlab/ImportAedatDataVersion1or2.m
+++ b/Matlab/ImportAedatDataVersion1or2.m
@@ -197,13 +197,15 @@ allTs = uint32(fread(fileHandle, numEventsToRead, addrPrecision, numBytesPerAddr
 
 if isfield(importParams, 'startTime')
     disp('Trimming to start time ...')
+	startTime = importParams.startTime;
 	tempIndex = allTs >= startTime * 1e6;
 	allAddr = allAddr(tempIndex);
 	allTs	= allTs(tempIndex);
 end
 
 if isfield(importParams, 'endTime')
-    disp('Trimming to end time ...')    
+    disp('Trimming to end time ...')
+	endTime = importParams.endTime; 
 	tempIndex = allTs <= endTime * 1e6;
 	allAddr = allAddr(tempIndex);
 	allTs	= allTs(tempIndex);


### PR DESCRIPTION
When I'm trying to import aedat2 by defining 'startTime' and 'endTime' using 'ImportAedatDataVersion1or2.m', I got error message telling 'endTime/startTime is not defined'.

The bug is fixed in this commit.